### PR TITLE
Remove src-docs

### DIFF
--- a/.github/pull_request_template.yaml
+++ b/.github/pull_request_template.yaml
@@ -25,7 +25,6 @@ Applicable spec: <link>
 - [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
 - [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
 - [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
-- [ ] The documentation is generated using `src-docs`
 - [ ] The documentation for charmhub is updated
 - [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,14 +42,6 @@ source .tox/unit/bin/activate
 * `tox -e unit`: Runs the unit tests.
 * `tox -e integration`: Runs the integration tests.
 
-### Generating src docs for every commit
-
-Run the following command:
-
-```bash
-echo -e "tox -e src-docs\ngit add src-docs\n" >> .git/hooks/pre-commit
-chmod +x .git/hooks/pre-commit
-```
 
 ## Build charm
 

--- a/generate-src-docs.sh
+++ b/generate-src-docs.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# Copyright 2025 Canonical Ltd.
-# See LICENSE file for licensing details.
-
-lazydocs --no-watermark --output-path src-docs src/*

--- a/tox.ini
+++ b/tox.ini
@@ -109,15 +109,3 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
-
-[testenv:src-docs]
-allowlist_externals=sh
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-description = Generate documentation for src
-deps =
-    lazydocs
-    -r{toxinidir}/requirements.txt
-commands =
-    ; can't run lazydocs directly due to needing to run it on src/* which produces an invocation error in tox
-    sh generate-src-docs.sh


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
