### PR TITLE
Use YAML list instead of comma-separated lists for configuration options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ options:
   additional_smtpd_recipient_restrictions:
     type: string
     description: |
-      Comma-separated list of additional smtpd_recipient_restrictions.
+      YAML list of additional smtpd_recipient_restrictions.
 
       http://www.postfix.org/postconf.5.html#smtpd_recipient_restrictions
   admin_email:
@@ -14,7 +14,7 @@ options:
   allowed_relay_networks:
     type: string
     description: |
-      Comma-separated list of allowed networks to relay without authenticating.
+      YAML list of allowed networks to relay without authenticating.
   append_x_envelope_to:
     type: boolean
     default: false
@@ -61,19 +61,19 @@ options:
   header_checks:
     type: string
     description: |
-      Comma-separated list of header checks to perform on incoming emails and action on. See:
+      YAML list of header checks to perform on incoming emails and action on. See:
 
       http://www.postfix.org/header_checks.5.html
   relay_access_sources:
     type: string
     description: |
-      Comma-separated list of entries to restrict access based on CIDR source per:
+      YAML list of entries to restrict access based on CIDR source per:
 
       http://www.postfix.org/cidr_table.5.html
   relay_domains:
     type: string
     description: |
-      Comma-separated list of destination domains this system will relay mail to.
+      YAML list of destination domains this system will relay mail to.
 
       http://www.postfix.org/postconf.5.html#relay_domains
   relay_host:
@@ -82,7 +82,7 @@ options:
   relay_recipient_maps:
     type: string
     description: |
-      Comma-separated list of lookup map entries that alias specific mail addresses or
+      YAML list of lookup map entries that alias specific mail addresses or
       domains to other local or remote addresses.
 
       Allows for all configured aliases and transports to be valid
@@ -91,38 +91,38 @@ options:
       http://www.postfix.org/postconf.5.html#relay_recipient_maps
   restrict_recipients:
     type: string
-    description: Comma-separated list of access map entries for restrictions by recipient address or domain.
+    description: YAML list of access map entries for restrictions by recipient address or domain.
   restrict_senders:
     type: string
-    description: Comma-separated list of access map entries for restrictions by sender address or domain.
+    description: YAML list of access map entries for restrictions by sender address or domain.
   restrict_sender_access:
     type: string
     description: |
-      Comma-separated list of domains, addresses, or hosts senders to restrict relay from.
+      YAML list of domains, addresses, or hosts senders to restrict relay from.
   sender_login_maps:
     type: string
     description: |
-      Comma-separated list of map entries that restrict sender addresses to authenticated users.
+      YAML list of map entries that restrict sender addresses to authenticated users.
 
       See https://www.postfix.org/postconf.5.html for details.
   smtp_auth_users:
     type: string
     description: |
-      Comma-separated list of user and crypt password hashes (use mkpasswd to
+      YAML list of user and crypt password hashes (use mkpasswd to
       generate). e.g.
 
-      myuser1:$1$bPb0IPiM$kmrSMZkZvICKKHXu66daQ.,myuser2:$6$3rGBbaMbEiGhnGKz$KLGFv8kDTjqa3xeUgA6A1Rie1zGSf3sLT85vF1s59Yj//F36qLB/J8rUfIIndaDtkxeb5iR3gs1uBn9fNyJDD1
+      myuser1:$1$bPb0IPiM$kmrSMZkZvICKKHXu66daQ.,myuser2:$6$3r//F36qLB/J8rUfIIndaDtkxeb5iR3gs1uBn9fNyJDD1
   smtp_header_checks:
     type: string
     description: |
-      Comma-separated list of header checks for outgoing email to perform and action on. See:
+      YAML list of header checks for outgoing email to perform and action on. See:
 
       http://www.postfix.org/header_checks.5.html
 
       NOTE: You almost always want to use `header_checks` instead of this.
   spf_skip_addresses:
     type: string
-    description:  Comma-separated list of CIDR addresses to skip SPF checks (allowlist).
+    description:  YAML list of CIDR addresses to skip SPF checks (allowlist).
   tls_ciphers:
     type: string
     default: 'HIGH'
@@ -138,9 +138,16 @@ options:
       http://www.postfix.org/postconf.5.html#smtpd_tls_ciphers
   tls_exclude_ciphers:
     type: string
-    default: 'aNULL,eNULL,DES,3DES,MD5,RC4,CAMELLIA'
+    default: |
+      - aNULL
+      - eNULL
+      - DES
+      - 3DES
+      - MD5
+      - RC4
+      - CAMELLIA
     description: |
-      Comma-separated list of ciphers or cipher types to exclude from the SMTP server
+      YAML list of ciphers or cipher types to exclude from the SMTP server
       cipher list at all TLS security levels. Excluding valid ciphers
       can create interoperability problems. DO NOT exclude ciphers
       unless it is essential to do so.
@@ -152,14 +159,16 @@ options:
   tls_policy_maps:
     type: string
     description: |
-      Comma-separated list of free-form TLS policy map entries per:
+      YAML list of free-form TLS policy map entries per:
 
       http://www.postfix.org/postconf.5.html#smtp_tls_policy_maps
   tls_protocols:
     type: string
-    default: '!SSLv2,!SSLv3'
+    default: |
+      - '!SSLv2'
+      - '!SSLv3'
     description: |
-      Comma-separated list of TLS protocols accepted by the Postfix SMTP server with TLS
+      YAML list of TLS protocols accepted by the Postfix SMTP server with TLS
       encryption. If the list is empty, the server supports all
       available TLS protocol versions. A non-empty value is a list of
       protocol names to include or exclude, separated by whitespace,
@@ -184,21 +193,21 @@ options:
   transport_maps:
     type: string
     description: |
-      Comma-separated list of mappings from recipient address to
+      YAML list of mappings from recipient address to
       message delivery transport or next-hop destination.
 
       http://www.postfix.org/postconf.5.html#transport_maps
   virtual_alias_domains:
     type: string
     description: |
-      Comma-separated list of domains for which all addresses are aliased to
+      YAML list of domains for which all addresses are aliased to
       addresses in other local or remote domains.
 
       http://www.postfix.org/postconf.5.html#virtual_alias_domains
   virtual_alias_maps:
     type: string
     description: |
-      Comma-separated list of lookup table entries that alias specific mail addresses or
+      YAML list of lookup table entries that alias specific mail addresses or
       domains to other local or remote addresses.
 
       http://www.postfix.org/postconf.5.html#virtual_alias_maps

--- a/reactive/state.py
+++ b/reactive/state.py
@@ -7,6 +7,7 @@ import itertools
 import logging
 import re
 import typing
+import yaml
 from enum import Enum
 
 from typing_extensions import Annotated
@@ -109,9 +110,7 @@ def _parse_map(raw_map: str) -> dict[str, str]:
     Raises:
         ConfigurationError: if the map is invalid.
     """
-    if not raw_map:
-        return {}
-    access_map_lines = raw_map.split(",")
+    access_map_lines = _parse_list(raw_map)
     access_map = {}
     for raw_line in access_map_lines:
         line = raw_line.split()
@@ -143,7 +142,7 @@ def _parse_list(raw_list: str) -> list[str]:
     Returns:
         a list of strings.
     """
-    return raw_list.split(",") if raw_list else []
+    return yaml.safe_load(raw_list) if raw_list else []
 
 
 @dataclasses.dataclass()

--- a/tests/unit/files/dovecot_users
+++ b/tests/unit/files/dovecot_users
@@ -1,4 +1,4 @@
 # This file is Juju managed - do not edit by hand #
 
 myuser1:$1$bPb0IPiM$kmrSMZkZvICKKHXu66daQ.
-myuser2:$6$3rGBbaMbEiGhnGKz$KLGFv8kDTjqa3xeUgA6A1Rie1zGSf3sLT85vF1s59Yj//F36qLB/J8rUfIIndaDtkxeb5iR3gs1uBn9fNyJDD1
+myuser2:$6$3r//F36qLB/J8rUfIIndaDtkxeb5iR3gs1uBn9fNyJDD1

--- a/tests/unit/files/relay_access_relay_access_sources
+++ b/tests/unit/files/relay_access_relay_access_sources
@@ -1,5 +1,4 @@
 # This file is Juju managed - do not edit by hand #
 
-# Reject some made user.
 10.10.10.5    REJECT
 10.10.10.0/24 OK

--- a/tests/unit/files/tls_policy
+++ b/tests/unit/files/tls_policy
@@ -1,7 +1,5 @@
 # This file is Juju managed - do not edit by hand #
 
-# Google hosted
 gapps.mydomain.local secure match=mx.google.com
-# Some place enforce encryption
 someplace.local encrypt
 .someplace.local encrypt


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
