### PR TITLE
Add integration test for relay charm

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,3 +12,4 @@ jobs:
       self-hosted-runner-label: "edge"
       juju-channel: 3/stable
       provider: 'lxd'
+      pre-run-script: ./tests/integration/mailcatcher-installation.sh

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,14 +5,6 @@ type: "charm"
 bases:
     - build-on:
       - name: "ubuntu"
-        channel: "20.04"
-        architectures: [amd64]
-      run-on:
-      - name: "ubuntu"
-        channel: "20.04"
-        architectures: [amd64, arm64, ppc64el, s390x]
-    - build-on:
-      - name: "ubuntu"
         channel: "22.04"
         architectures: [amd64]
       run-on:
@@ -24,6 +16,8 @@ parts:
     source: "."
     plugin: "reactive"
     build-snaps:
-      - charm/2.x/stable
+      - charm/3.x/stable
     reactive-charm-build-arguments:
+      - --binary-wheels-from-source
       - --verbose
+      - --debug

--- a/layer.yaml
+++ b/layer.yaml
@@ -12,3 +12,5 @@ options:
       - dovecot-common
       - postfix
       - postfix-policyd-spf-python
+    use_venv: true
+    include_system_packages: false

--- a/reactive/charm.py
+++ b/reactive/charm.py
@@ -13,8 +13,9 @@ import jinja2
 from charms import reactive
 from charms.layer import status
 from charmhelpers.core import hookenv, host
-import utils
-from state import State
+
+from reactive import utils
+from reactive.state import State
 
 
 JUJU_HEADER = '# This file is Juju managed - do not edit by hand #\n\n'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,4 +10,4 @@ def pytest_addoption(parser):
     Args:
         parser: Pytest parser.
     """
-    parser.addoption("--charm-file", action="store")
+    parser.addoption("--charm-file", action="store", help="Charm file to be deployed")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,6 @@ def deploy_smtp_relay_fixture(
         juju.deploy(
             f"./{smtp_relay_charm}",
             smtp_relay_app_name,
-            config={"relay_domains": "- testrelay.internal"},
         )
     juju.wait(
         lambda status: status.apps[smtp_relay_app_name].is_active,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,71 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import typing
+from collections.abc import Generator
+
+import jubilant
+import pytest
+
+
+@pytest.fixture(scope="module", name="smtp_relay_charm")
+def smtp_relay_charm_fixture(pytestconfig: pytest.Config):
+    """Get value from parameter charm-file."""
+    charm = pytestconfig.getoption("--charm-file")
+    use_existing = pytestconfig.getoption("--use-existing", default=False)
+    if not use_existing:
+        assert charm, "--charm-file must be set"
+    return charm
+
+
+@pytest.fixture(scope="module", name="smtp_relay_app")
+def deploy_smtp_relay_fixture(
+    smtp_relay_charm: str,
+    juju: jubilant.Juju,
+) -> str:
+    """Deploy smtp-relay."""
+    smtp_relay_app_name = "smtp-relay"
+
+    if not juju.status().apps.get(smtp_relay_app_name):
+        juju.deploy(
+            f"./{smtp_relay_charm}",
+            smtp_relay_app_name,
+            config={"relay_domains": "testrelay.internal"},
+        )
+    juju.wait(
+        lambda status: status.apps[smtp_relay_app_name].is_active,
+        error=jubilant.any_blocked,
+        timeout=6 * 60,
+    )
+    return smtp_relay_app_name
+
+
+@pytest.fixture(scope="session")
+def juju(request: pytest.FixtureRequest) -> Generator[jubilant.Juju, None, None]:
+    """Pytest fixture that wraps :meth:`jubilant.with_model`."""
+
+    def show_debug_log(juju: jubilant.Juju):
+        if request.session.testsfailed:
+            log = juju.debug_log(limit=1000)
+            print(log, end="")
+
+    use_existing = request.config.getoption("--use-existing", default=False)
+    if use_existing:
+        juju = jubilant.Juju()
+        yield juju
+        show_debug_log(juju)
+        return
+
+    model = request.config.getoption("--model")
+    if model:
+        juju = jubilant.Juju(model=model)
+        yield juju
+        show_debug_log(juju)
+        return
+
+    keep_models = typing.cast(bool, request.config.getoption("--keep-models"))
+    with jubilant.temp_model(keep=keep_models) as juju:
+        juju.wait_timeout = 10 * 60
+        yield juju
+        show_debug_log(juju)
+        return

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -30,7 +30,7 @@ def deploy_smtp_relay_fixture(
         juju.deploy(
             f"./{smtp_relay_charm}",
             smtp_relay_app_name,
-            config={"relay_domains": "testrelay.internal"},
+            config={"relay_domains": "- testrelay.internal"},
         )
     juju.wait(
         lambda status: status.apps[smtp_relay_app_name].is_active,

--- a/tests/integration/mailcatcher-installation.sh
+++ b/tests/integration/mailcatcher-installation.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+set -euxo pipefail
+
+sudo docker run --rm -d -p 1080:1080 -p 25:1025 sj26/mailcatcher

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,34 +5,62 @@
 
 """Integration tests."""
 
-import asyncio
 import logging
-from pathlib import Path
+import smtplib
+import socket
+import time
 
+import jubilant
 import pytest
-import yaml
-from pytest_operator.plugin import OpsTest
+import requests
 
 logger = logging.getLogger(__name__)
 
-METADATA = yaml.safe_load(Path("./metadata.yaml").read_text(encoding="utf-8"))
-APP_NAME = METADATA["name"]
+
+@pytest.fixture(scope="session", name="machine_ip_address")
+def machine_ip_address_fixture() -> str:
+    """IP address for the machine running the tests."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.connect(("8.8.8.8", 80))
+    ip_address = s.getsockname()[0]
+    logger.info("IP Address for the current test runner: %s", ip_address)
+    s.close()
+    return ip_address
 
 
 @pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, pytestconfig: pytest.Config):
-    """Deploy the charm together with related charms.
-
-    Assert on the unit status before any relations/configurations take place.
+def test_simple_relay(juju: jubilant.Juju, smtp_relay_app, machine_ip_address):
     """
-    # Deploy the charm and wait for active/idle status
-    charm = pytestconfig.getoption("--charm-file")
-    assert ops_test.model
-    await asyncio.gather(
-        ops_test.model.deploy(
-            f"./{charm}", application_name=APP_NAME, series="jammy"
-        ),
-        ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
-        ),
+    arrange: Deploy smtp-relay charm with the testrelay.internal domain in relay domains.
+    act: Send an email to an address with the testrelay.internal domain.
+    assert: The email is correctly relayed to the mailcatcher local test smtp server.
+    """
+    mailcatcher_url = "http://127.0.0.1:1080/messages"
+    messages = requests.get(mailcatcher_url, timeout=5).json()
+    # There should not be any message in mailcatcher before the test.
+    assert len(messages) == 0
+    status = juju.status()
+
+    unit = list(status.apps[smtp_relay_app].units.values())[0]
+    unit_ip = unit.public_address
+
+    command_to_put_domain = (
+        f"echo {machine_ip_address} testrelay.internal | sudo tee -a /etc/hosts"
     )
+    juju.exec(machine=unit.machine, command=command_to_put_domain)
+
+    with smtplib.SMTP(unit_ip) as server:
+        server.set_debuglevel(2)
+        from_addr = "Some One <someone@testrelay.internal>"
+        to_addrs = ["otherone@testrelay.internal"]
+        server.sendmail(from_addr=from_addr, to_addrs=to_addrs, msg="Hello World!")
+
+    for _ in range(5):
+        messages = requests.get(mailcatcher_url, timeout=5).json()
+        if messages:
+            break
+        time.sleep(1)
+    assert len(messages) == 1
+
+    # Clean up mailcatcher
+    requests.delete(f"{mailcatcher_url}/{messages[0]['id']}", timeout=5)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -35,6 +35,7 @@ def test_simple_relay(juju: jubilant.Juju, smtp_relay_app, machine_ip_address):
     act: Send an email to an address with the testrelay.internal domain.
     assert: The email is correctly relayed to the mailcatcher local test smtp server.
     """
+    status = juju.status()
     unit = list(status.apps[smtp_relay_app].units.values())[0]
     unit_ip = unit.public_address
 
@@ -47,7 +48,6 @@ def test_simple_relay(juju: jubilant.Juju, smtp_relay_app, machine_ip_address):
     messages = requests.get(mailcatcher_url, timeout=5).json()
     # There should not be any message in mailcatcher before the test.
     assert len(messages) == 0
-    status = juju.status()
 
     with smtplib.SMTP(unit_ip) as server:
         server.set_debuglevel(2)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -44,6 +44,13 @@ def test_simple_relay(juju: jubilant.Juju, smtp_relay_app, machine_ip_address):
     )
     juju.exec(machine=unit.machine, command=command_to_put_domain)
 
+    juju.config(smtp_relay_app, {"relay_domains": "- testrelay.internal"})
+    juju.wait(
+        lambda status: status.apps[smtp_relay_app].is_active,
+        error=jubilant.any_blocked,
+        timeout=6 * 60,
+    )
+
     mailcatcher_url = "http://127.0.0.1:1080/messages"
     messages = requests.get(mailcatcher_url, timeout=5).json()
     # There should not be any message in mailcatcher before the test.

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -35,12 +35,6 @@ def test_simple_relay(juju: jubilant.Juju, smtp_relay_app, machine_ip_address):
     act: Send an email to an address with the testrelay.internal domain.
     assert: The email is correctly relayed to the mailcatcher local test smtp server.
     """
-    mailcatcher_url = "http://127.0.0.1:1080/messages"
-    messages = requests.get(mailcatcher_url, timeout=5).json()
-    # There should not be any message in mailcatcher before the test.
-    assert len(messages) == 0
-    status = juju.status()
-
     unit = list(status.apps[smtp_relay_app].units.values())[0]
     unit_ip = unit.public_address
 
@@ -48,6 +42,12 @@ def test_simple_relay(juju: jubilant.Juju, smtp_relay_app, machine_ip_address):
         f"echo {machine_ip_address} testrelay.internal | sudo tee -a /etc/hosts"
     )
     juju.exec(machine=unit.machine, command=command_to_put_domain)
+
+    mailcatcher_url = "http://127.0.0.1:1080/messages"
+    messages = requests.get(mailcatcher_url, timeout=5).json()
+    # There should not be any message in mailcatcher before the test.
+    assert len(messages) == 0
+    status = juju.status()
 
     with smtplib.SMTP(unit_ip) as server:
         server.set_debuglevel(2)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -268,7 +268,7 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch('charms.reactive.clear_flag')
     @mock.patch('charms.reactive.set_flag')
-    @mock.patch('utils.write_file')
+    @mock.patch('reactive.utils.write_file')
     def test_configure_smtp_auth_relay_flags(self, write_file, set_flag, clear_flag):
         self.mock_config.return_value['enable_smtp_auth'] = True
         charm.configure_smtp_auth()
@@ -299,7 +299,7 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch('charms.reactive.clear_flag')
     @mock.patch('charms.reactive.set_flag')
-    @mock.patch('utils.write_file')
+    @mock.patch('reactive.utils.write_file')
     def test_configure_smtp_auth_relay_ports(self, write_file, set_flag, clear_flag):
         self.mock_config.return_value['enable_smtp_auth'] = True
         charm.configure_smtp_auth()
@@ -545,7 +545,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch('reactive.charm._get_autocert_cn')
     @mock.patch('reactive.charm._get_milters')
     @mock.patch('reactive.charm._update_aliases')
-    @mock.patch('utils.write_file')
+    @mock.patch('reactive.utils.write_file')
     @mock.patch('subprocess.call')
     def test_configure_smtp_relay_config_tls_dhparam_non_exists(
         self,
@@ -572,7 +572,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch('reactive.charm._get_autocert_cn')
     @mock.patch('reactive.charm._get_milters')
     @mock.patch('reactive.charm._update_aliases')
-    @mock.patch('utils.write_file')
+    @mock.patch('reactive.utils.write_file')
     @mock.patch('subprocess.call')
     def test_configure_smtp_relay_config_tls_dhparam_exists(
         self,
@@ -1296,7 +1296,7 @@ class TestCharm(unittest.TestCase):
     @mock.patch('reactive.charm._get_autocert_cn')
     @mock.patch('reactive.charm._get_milters')
     @mock.patch('reactive.charm._update_aliases')
-    @mock.patch('utils.write_file')
+    @mock.patch('reactive.utils.write_file')
     @mock.patch('subprocess.call')
     def test_configure_smtp_relay_flags(
         self, call, write_file, update_aliases, get_milters, get_cn, set_flag, clear_flag

--- a/tox.ini
+++ b/tox.ini
@@ -106,10 +106,10 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.6.1.3
+    juju==3.6
     pytest
-    pytest-asyncio
     pytest-operator
+    jubilant == 1.4.0
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,0 +1,3 @@
+typing_extensions==4.15.0
+email-validator==2.3.0
+pydantic==2.11.7


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

This PR creates a simple integration test for the smtp-relay.

As the charm was not being created the following changes have been made, besides the integration test:
- Remove base 20.04
- Upgrade charm/2.x/stable to charm/3.x/stable, as pydantic did not compile with an old version of Python.
- Add args to reactive-charm-build-arguments to be able to put pydantic in the charm.
- As the path.sys for the charm is not inside the reactive directory, the imports from reactive import utils and from reactive.state import State are necessary instead of a plain import utils or from State import state.
- Added wheelhouse.txt with the requirements for the charm.
- The integration test uses mailcatcher, which is run with docker.


### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
