### PR TITLE
Use YAML maps instead of YAML lists of entries for configuration options

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,7 +82,7 @@ options:
   relay_recipient_maps:
     type: string
     description: |
-      YAML list of lookup map entries that alias specific mail addresses or
+      YAML map of lookups that alias specific mail addresses or
       domains to other local or remote addresses.
 
       Allows for all configured aliases and transports to be valid
@@ -91,10 +91,10 @@ options:
       http://www.postfix.org/postconf.5.html#relay_recipient_maps
   restrict_recipients:
     type: string
-    description: YAML list of access map entries for restrictions by recipient address or domain.
+    description: YAML map for restrictions by recipient address or domain.
   restrict_senders:
     type: string
-    description: YAML list of access map entries for restrictions by sender address or domain.
+    description: YAML map for restrictions by sender address or domain.
   restrict_sender_access:
     type: string
     description: |
@@ -102,7 +102,7 @@ options:
   sender_login_maps:
     type: string
     description: |
-      YAML list of map entries that restrict sender addresses to authenticated users.
+      YAML map with entries to sender addresses to authenticated users.
 
       See https://www.postfix.org/postconf.5.html for details.
   smtp_auth_users:
@@ -159,7 +159,7 @@ options:
   tls_policy_maps:
     type: string
     description: |
-      YAML list of free-form TLS policy map entries per:
+      YAML map of free-form TLS policy map per:
 
       http://www.postfix.org/postconf.5.html#smtp_tls_policy_maps
   tls_protocols:
@@ -193,7 +193,7 @@ options:
   transport_maps:
     type: string
     description: |
-      YAML list of mappings from recipient address to
+      YAML map from recipient address to
       message delivery transport or next-hop destination.
 
       http://www.postfix.org/postconf.5.html#transport_maps
@@ -207,7 +207,7 @@ options:
   virtual_alias_maps:
     type: string
     description: |
-      YAML list of lookup table entries that alias specific mail addresses or
+      YAML map of lookup table entries that alias specific mail addresses or
       domains to other local or remote addresses.
 
       http://www.postfix.org/postconf.5.html#virtual_alias_maps

--- a/reactive/charm.py
+++ b/reactive/charm.py
@@ -268,7 +268,11 @@ def configure_smtp_relay(
         'append_envelope_to_header': '/^(.*)$/ PREPEND X-Envelope-To: $1',
         'header_checks': ";".join(charm_state.header_checks),
         'relay_access_sources': "\n".join(charm_state.relay_access_sources),
-        'relay_recipient_maps': "\n".join(charm_state.relay_recipient_maps),
+        'relay_recipient_maps': "\n".join(
+            [
+                f"{key} {value}" for key, value in charm_state.relay_recipient_maps.items()
+            ]
+        ),
         'restrict_recipients': "\n".join(
             [
                 f"{key} {value.value}" for key, value in charm_state.restrict_recipients.items()
@@ -282,13 +286,19 @@ def configure_smtp_relay(
         'sender_access': sender_access_content,
         'sender_login_maps': "\n".join(
             [
-                f"{key} {value.value}" for key, value in charm_state.sender_login_maps.items()
+                f"{key} {value}" for key, value in charm_state.sender_login_maps.items()
             ]
         ),
         'smtp_header_checks': ";".join(charm_state.smtp_header_checks),
-        'tls_policy_maps': "\n".join(charm_state.tls_policy_maps),
-        'transport_maps': "\n".join(charm_state.transport_maps),
-        'virtual_alias_maps': "\n".join(charm_state.virtual_alias_maps),
+        'tls_policy_maps': "\n".join([
+            f"{key} {value}" for key, value in charm_state.tls_policy_maps.items()
+        ]),
+        'transport_maps': "\n".join([
+            f"{key} {value}" for key, value in charm_state.transport_maps.items()
+        ]),
+        'virtual_alias_maps': "\n".join([
+            f"{key} {value}" for key, value in charm_state.virtual_alias_maps.items()
+        ]),
     }
 
     # Ensure various maps exists before starting/restarting postfix.

--- a/reactive/state.py
+++ b/reactive/state.py
@@ -106,18 +106,8 @@ def _parse_map(raw_map: str) -> dict[str, str]:
 
     Returns:
         the parsed map.
-
-    Raises:
-        ConfigurationError: if the map is invalid.
     """
-    access_map_lines = _parse_list(raw_map)
-    access_map = {}
-    for raw_line in access_map_lines:
-        line = raw_line.split()
-        if len(line) != 2:
-            raise ConfigurationError(f"Invalid map {raw_map}")
-        access_map.update({line[0]: line[1]})
-    return access_map
+    return yaml.safe_load(raw_map) if raw_map else {}
 
 
 def _parse_access_map(raw_map: str) -> dict[str, AccessMapValue]:
@@ -166,7 +156,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
         restrict_recipients: Access map for restrictions by recipient address or domain.
         restrict_senders: Access map for restrictions by sender address or domain.
         relay_host: SMTP relay host to forward mail to.
-        relay_recipient_maps: List of of mappings that alias mail addresses or domains to
+        relay_recipient_maps: Map that alias mail addresses or domains to
             addresses.
         restrict_sender_access: List of domains, addresses or hosts to restrict relay from.
         sender_login_maps: List of authenticated users that can send mail.
@@ -175,13 +165,13 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
         spf_skip_addresses: List of CIDR addresses to skip SPF checks.
         tls_ciphers: Minimum TLS cipher grade for TLS encryption.
         tls_exclude_ciphers: List of TLS ciphers or cipher types to exclude from the cipher list.
-        tls_policy_maps: List of of mappings for TLS policy.
+        tls_policy_maps: Map for TLS policy.
         tls_protocols: List of TLS protocols accepted by the Postfix SMTP.
         tls_security_level: The TLS security level.
-        transport_maps: List of mappings from recipient address to message delivery transport
+        transport_maps: Map from recipient address to message delivery transport
             or next-hop destination.
         virtual_alias_domains: List of domains for which all addresses are aliased.
-        virtual_alias_maps: List of aliases of mail addresses or domains to other local or
+        virtual_alias_maps: Map of aliases of mail addresses or domains to other local or
             remote addresses.
         virtual_alias_maps_type: The virtual alias map type.
     """
@@ -201,7 +191,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
     restrict_recipients: dict[str, AccessMapValue]
     restrict_senders: dict[str, AccessMapValue]
     relay_host: Annotated[str, Field(min_length=1)] | None
-    relay_recipient_maps: list[str]
+    relay_recipient_maps: dict[str, str]
     restrict_sender_access: list[Annotated[str, Field(min_length=1)]]
     sender_login_maps: dict[str, str]
     smtp_auth_users: list[str]
@@ -209,12 +199,12 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
     spf_skip_addresses: list[IPvAnyNetwork]
     tls_ciphers: SmtpTlsCipherGrade | None
     tls_exclude_ciphers: list[Annotated[str, Field(min_length=1)]]
-    tls_policy_maps: list[str]
+    tls_policy_maps: dict[str, str]
     tls_protocols: list[Annotated[str, Field(min_length=1)]]
     tls_security_level: SmtpTlsSecurityLevel | None
-    transport_maps: list[str]
+    transport_maps: dict[str, str]
     virtual_alias_domains: list[Annotated[str, Field(min_length=1)]]
-    virtual_alias_maps: list[str]
+    virtual_alias_maps: dict[str, str]
     virtual_alias_maps_type: PostfixLookupTableType
     connection_limit: int = Field(ge=0)
 
@@ -235,7 +225,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
         restrict_recipients: dict[str, AccessMapValue],
         restrict_senders: dict[str, AccessMapValue],
         relay_host: Annotated[str, Field(min_length=1)] | None,
-        relay_recipient_maps: list[str],
+        relay_recipient_maps: dict[str, str],
         restrict_sender_access: list[Annotated[str, Field(min_length=1)]],
         sender_login_maps: dict[str, str],
         smtp_auth_users: list[str],
@@ -243,12 +233,12 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
         spf_skip_addresses: list[IPvAnyNetwork],
         tls_ciphers: SmtpTlsCipherGrade | None,
         tls_exclude_ciphers: list[Annotated[str, Field(min_length=1)]],
-        tls_policy_maps: list[str],
+        tls_policy_maps: dict[str, str],
         tls_protocols: list[Annotated[str, Field(min_length=1)]],
         tls_security_level: SmtpTlsSecurityLevel | None,
-        transport_maps: list[str],
+        transport_maps: dict[str, str],
         virtual_alias_domains: list[Annotated[str, Field(min_length=1)]],
-        virtual_alias_maps: list[str],
+        virtual_alias_maps: dict[str, str],
         virtual_alias_maps_type: PostfixLookupTableType,
         connection_limit: int = Field(ge=0)
     ):
@@ -272,7 +262,7 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
             restrict_recipients: Access map for restrictions by recipient address or domain.
             restrict_senders: Access map for restrictions by sender address or domain.
             relay_host: SMTP relay host to forward mail to.
-            relay_recipient_maps: List of of mappings that alias mail addresses or domains to
+            relay_recipient_maps: Map that alias mail addresses or domains to
                 addresses.
             restrict_sender_access: List of domains, addresses or hosts to restrict relay from.
             sender_login_maps: List of authenticated users that can send mail.
@@ -282,13 +272,13 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
             tls_ciphers: Minimum TLS cipher grade for TLS encryption.
             tls_exclude_ciphers: List of TLS ciphers or cipher types to exclude from the cipher
                 list.
-            tls_policy_maps: List of of mappings for TLS policy.
+            tls_policy_maps:Map for TLS policy.
             tls_protocols: List of TLS protocols accepted by the Postfix SMTP.
             tls_security_level: The TLS security level.
-            transport_maps: List of mappings from recipient address to message delivery transport
+            transport_maps: Map for recipient address to message delivery transport
                 or next-hop destination.
             virtual_alias_domains: List of domains for which all addresses are aliased.
-            virtual_alias_maps: List of aliases of mail addresses or domains to other local or
+            virtual_alias_maps: Map of aliases of mail addresses or domains to other local or
                 remote addresses.
             virtual_alias_maps_type: The virtual alias map type.
         """
@@ -368,11 +358,11 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
             header_checks = _parse_list(config.get("header_checks"))
             relay_access_sources = _parse_list(config.get("relay_access_sources"))
             relay_domains = _parse_list(config.get("relay_domains"))
-            relay_recipient_maps = _parse_list(config.get("relay_recipient_maps"))
+            relay_recipient_maps = _parse_map(config.get("relay_recipient_maps"))
             restrict_sender_access = _parse_list(config.get("restrict_sender_access"))
             spf_skip_addresses = _parse_list(config.get("spf_skip_addresses"))
             tls_exclude_ciphers = _parse_list(config.get("tls_exclude_ciphers"))
-            tls_policy_maps = _parse_list(config.get("tls_policy_maps"))
+            tls_policy_maps = _parse_map(config.get("tls_policy_maps"))
             tls_protocols = _parse_list(config.get("tls_protocols"))
             virtual_alias_domains = _parse_list(config.get("virtual_alias_domains"))
             restrict_recipients = _parse_access_map(config.get("restrict_recipients"))
@@ -380,8 +370,8 @@ class State(BaseModel):  # pylint: disable=too-few-public-methods,too-many-insta
             sender_login_maps = _parse_map(config.get("sender_login_maps"))
             smtp_auth_users = _parse_list(config.get("smtp_auth_users"))
             smtp_header_checks = _parse_list(config.get("smtp_header_checks"))
-            transport_maps = _parse_list(config.get("transport_maps"))
-            virtual_alias_maps = _parse_list(config.get("virtual_alias_maps"))
+            transport_maps = _parse_map(config.get("transport_maps"))
+            virtual_alias_maps = _parse_map(config.get("virtual_alias_maps"))
 
             return cls(
                 additional_smtpd_recipient_restrictions=additional_smtpd_recipient_restrictions,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -796,8 +796,8 @@ class TestCharm(unittest.TestCase):
         postfix_main_cf = os.path.join(self.tmpdir, 'main.cf')
         get_cn.return_value = ''
         get_milters.return_value = ''
-        self.mock_config.return_value['restrict_recipients'] = '- mydomain.local  OK'
-        self.mock_config.return_value['restrict_senders'] = '- noreply@mydomain.local  OK'
+        self.mock_config.return_value['restrict_recipients'] = 'mydomain.local: OK'
+        self.mock_config.return_value['restrict_senders'] = 'noreply@mydomain.local: OK'
         charm.configure_smtp_relay(self.tmpdir)
         with open(
             'tests/unit/files/postfix_main_restrict_both_senders_and_recipients.cf',
@@ -822,7 +822,7 @@ class TestCharm(unittest.TestCase):
         postfix_restricted_recipients = os.path.join(self.tmpdir, 'restricted_recipients')
         get_cn.return_value = ''
         get_milters.return_value = ''
-        self.mock_config.return_value['restrict_recipients'] = '- mydomain.local  OK'
+        self.mock_config.return_value['restrict_recipients'] = 'mydomain.local: OK'
         charm.configure_smtp_relay(self.tmpdir)
         with open(
             'tests/unit/files/postfix_main_restrict_recipients.cf', 'r', encoding='utf-8'
@@ -850,7 +850,7 @@ class TestCharm(unittest.TestCase):
         postfix_restricted_senders = os.path.join(self.tmpdir, 'restricted_senders')
         get_cn.return_value = ''
         get_milters.return_value = ''
-        self.mock_config.return_value['restrict_senders'] = '- noreply@mydomain.local  OK'
+        self.mock_config.return_value['restrict_senders'] = 'noreply@mydomain.local: OK'
         charm.configure_smtp_relay(self.tmpdir)
         with open('tests/unit/files/postfix_main_restrict_senders.cf', 'r', encoding='utf-8') as f:
             want = f.read()
@@ -945,10 +945,10 @@ class TestCharm(unittest.TestCase):
             'tls_policy_maps'
         ] = """
             # Google hosted
-            - gapps.mydomain.local secure match=mx.google.com
+            gapps.mydomain.local: secure match=mx.google.com
             # Some place enforce encryption
-            - someplace.local encrypt
-            - .someplace.local encrypt
+            someplace.local: encrypt
+            .someplace.local: encrypt
         """
         charm.configure_smtp_relay(self.tmpdir)
         with open('tests/unit/files/postfix_main_tls_policy.cf', 'r', encoding='utf-8') as f:
@@ -1003,7 +1003,7 @@ class TestCharm(unittest.TestCase):
             - mydomain2.local
         """
         self.mock_config.return_value['relay_recipient_maps'] = (
-            '- noreply@mydomain.local noreply@mydomain.local'
+            'noreply@mydomain.local: noreply@mydomain.local'
         )
         charm.configure_smtp_relay(self.tmpdir)
         with open(
@@ -1034,7 +1034,7 @@ class TestCharm(unittest.TestCase):
         get_cn.return_value = ''
         get_milters.return_value = ''
         self.mock_config.return_value['transport_maps'] = (
-            '- .mydomain.local  smtp:[smtp.mydomain.local]'
+            ".mydomain.local: 'smtp:[smtp.mydomain.local]'"
         )
         charm.configure_smtp_relay(self.tmpdir)
         with open('tests/unit/files/postfix_main_transport_maps.cf', 'r', encoding='utf-8') as f:
@@ -1042,7 +1042,7 @@ class TestCharm(unittest.TestCase):
         with open(postfix_main_cf, 'r', encoding='utf-8') as f:
             got = f.read()
         self.assertEqual(want, got)
-        want = charm.JUJU_HEADER + '.mydomain.local  smtp:[smtp.mydomain.local]' + "\n"
+        want = charm.JUJU_HEADER + '.mydomain.local smtp:[smtp.mydomain.local]' + "\n"
         with open(postfix_transport_maps, 'r', encoding='utf-8') as f:
             got = f.read()
         self.assertEqual(want, got)
@@ -1062,7 +1062,7 @@ class TestCharm(unittest.TestCase):
         get_milters.return_value = ''
         self.mock_config.return_value['header_checks'] = '- /^Received:/ HOLD'
         self.mock_config.return_value['transport_maps'] = (
-            '- .mydomain.local  smtp:[smtp.mydomain.local]'
+            ".mydomain.local: 'smtp:[smtp.mydomain.local]'"
         )
         charm.configure_smtp_relay(self.tmpdir)
         with open(
@@ -1074,7 +1074,7 @@ class TestCharm(unittest.TestCase):
         with open(postfix_main_cf, 'r', encoding='utf-8') as f:
             got = f.read()
         self.assertEqual(want, got)
-        want = charm.JUJU_HEADER + '.mydomain.local  smtp:[smtp.mydomain.local]' + "\n"
+        want = charm.JUJU_HEADER + '.mydomain.local smtp:[smtp.mydomain.local]' + "\n"
         with open(postfix_transport_maps, 'r', encoding='utf-8') as f:
             got = f.read()
         self.assertEqual(want, got)
@@ -1097,14 +1097,14 @@ class TestCharm(unittest.TestCase):
             - mydomain2.local
         """
         self.mock_config.return_value['transport_maps'] = """
-            - .mydomain.local  smtp:[smtp.mydomain.local]
+            .mydomain.local: 'smtp:[smtp.mydomain.local]'
         """
         self.mock_config.return_value['virtual_alias_domains'] = """
             - mydomain.local
             - mydomain2.local
         """
         self.mock_config.return_value['virtual_alias_maps'] = """
-            - abuse@mydomain.local sysadmin@mydomain.local
+            abuse@mydomain.local: sysadmin@mydomain.local
         """
         charm.configure_smtp_relay(self.tmpdir)
         with open(
@@ -1134,7 +1134,7 @@ class TestCharm(unittest.TestCase):
         get_cn.return_value = ''
         get_milters.return_value = ''
         self.mock_config.return_value['virtual_alias_maps'] = (
-            '- abuse@mydomain.local sysadmin@mydomain.local'
+            'abuse@mydomain.local: sysadmin@mydomain.local'
         )
         self.mock_config.return_value['virtual_alias_maps_type'] = 'regexp'
         charm.configure_smtp_relay(self.tmpdir)
@@ -1281,7 +1281,7 @@ class TestCharm(unittest.TestCase):
         get_cn.return_value = ''
         get_milters.return_value = ''
         self.mock_config.return_value['enable_spf'] = True
-        self.mock_config.return_value['restrict_senders'] = '- noreply@mydomain.local  OK'
+        self.mock_config.return_value['restrict_senders'] = 'noreply@mydomain.local: OK'
         charm.configure_smtp_relay(self.tmpdir)
         with open(
             'tests/unit/files/postfix_main_spf_with_restrict_senders.cf', 'r', encoding='utf-8'


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
